### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "js/index.d.ts",
   "style": "css/all.css",
   "sideEffects": false,
+  "type": "module",
   "scripts": {
     "clean": "rimraf css",
     "css": "npm-run-all --parallel css-compile* --sequential css-prefix css-concat css-minify",


### PR DESCRIPTION
Because of the fact that you're using import, specifying the type as a module will allow it to be imported easily into node.js projects. Since this is not common.js (Doesn't use `require()`), this does not integrate very well with any node.js project (In my specific case next.js).