### PR TITLE
🐛 Fix broken link in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ CoreUI Icons Free License
 
 CoreUI Icons Free is free, open source, and GPL friendly. You can use it for
 commercial projects, open source projects, or really almost whatever you want.
-Full CoreUI Icons Free license: https://coreui.io/icons/license/.
+Full CoreUI Icons Free license: https://icons.coreui.io/license/.
 
 # Icons: CC BY 4.0 License (https://creativecommons.org/licenses/by/4.0/)
 In the CoreUI Icons Free download, the CC BY 4.0 license applies to all icons


### PR DESCRIPTION
The website points to https://icons.coreui.io/license/
as the main point of reference for the license for this project.

However, this seems to be for the "PRO" version?

---

The LICENSE might need to be reworded. It looks like it was last updated ~2 years ago for the 1.0 release, so some of the points it raises could be out of date.